### PR TITLE
Update to work with Ubuntu 24 LTS / Noble.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 ## If you change this version, make sure you run 'make clean'
-VERSION=20240202
+VERSION=20240916
 RELEASE=1
 
 ## Set this to be the name of the Ubunt disto. It's used to tag
 ## the versions correctly
-BUILDNAME=jammy
+BUILDNAME=noble
 
 ## This SHOULD be in Makefile.settings but it's the most
 ## common thing to change. This is used as the end part of the

--- a/basedocker/Dockerfile
+++ b/basedocker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:noble
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -17,7 +17,7 @@ ENV CCACHE_CONFIGPATH=/usr/local/ccache/ccache.conf
 # Standard packages
 RUN apt-get -y install build-essential autoconf libtool libtool-bin vim xz-utils \
 	devscripts cowbuilder git screen ccache debhelper libtiff-dev libjpeg-dev \
-	dpatch doxygen autotools-dev xsltproc libxml2-utils docbook-xsl docbook \
+	doxygen autotools-dev xsltproc libxml2-utils docbook-xsl docbook \
 	xz-utils pkgconf uuid uuid-dev cmake libssl-dev libcurl4-openssl-dev \
 	libjansson-dev libjansson4 software-properties-common check libglib2.0-dev \
 	graphviz libuuid1
@@ -36,8 +36,8 @@ RUN apt-get -y install librabbitmq-dev libsnmp-dev libmagickcore-dev libopusfile
 	flite1-dev libgdbm-compat-dev autoconf-archive
 
 # This is run last to make sure everything is set back to python2, from python3
-RUN apt-get -y install python2-dev dh-python
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+#RUN apt-get -y install python2-dev dh-python
+#RUN update-alternatives --install /usr/bin/python python /usr/bin/python2 1
 
 # Let my people paste!
 RUN echo "bind 'set enable-bracketed-paste off'" >> /etc/bash.bashrc


### PR DESCRIPTION
 We're only interested in libspandsp3, so have tested as far as `make stage1`. 

`make fsdocker` fails with:

```
gnalwire-freeswitch-9df3076/debian fsdocker:20240916 ./bootstrap.sh -cnoble
Unable to find image 'fsdocker:20240916' locally
docker: Error response from daemon: pull access denied for fsdocker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
make: *** [includes/Makefile.freeswitch:14: fsdocker] Error 125
```

which I haven't look into, but suspect is my setup.


and `make freeswitch` fails with:

```
 > [2/4] RUN apt-get -y install python-all-dev python3-dev:                                                                                                  
1.437 Reading package lists...                                                                                                                               
2.643 Building dependency tree...                                                                                                                            
3.053 Reading state information...                                                                                                                           
3.117 Package python-all-dev is not available, but is referred to by another package.                                                                        
3.117 This may mean that the package is missing, has been obsoleted, or
3.117 is only available from another source
3.117 
3.119 E: Package 'python-all-dev' has no installation candidate
------

 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG basedocker:${VERSION} results in empty or invalid base image name (line 2)
Dockerfile:4
--------------------
   2 |     FROM basedocker:${VERSION}
   3 |     
   4 | >>> RUN apt-get -y install python-all-dev python3-dev
   5 |     
   6 |     ENV FS_FILES_DIR=/usr/local/build/SOURCES
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -y install python-all-dev python3-dev" did not complete successfully: exit code: 100
```

Thanks.